### PR TITLE
Add a unique key for uri

### DIFF
--- a/solr/managed-schema.xml
+++ b/solr/managed-schema.xml
@@ -2,6 +2,7 @@
 <!-- Solr managed schema - automatically generated - DO NOT EDIT -->
 <schema name="file_system" version="1.6">
   <uniqueKey>file</uniqueKey>
+  <uniqueKey>uri</uniqueKey>
   <fieldType name="pdate" class="solr.DatePointField" docValues="true"/>
   <fieldType name="rdate" class="solr.DateRangeField"/>
   <fieldType name="pdates" class="solr.DatePointField" docValues="true" multiValued="true"/>
@@ -32,6 +33,7 @@
 
   <field name="_version_" type="plong" indexed="true" stored="true"/>
   <field name="file" type="string" multiValued="false" indexed="true" required="true" stored="true"/>
+  <field name="uri" type="string" multiValued="false" indexed="true" required="true" stored="true"/>
   <field name="timestamp" type="pfloat" indexed="false" stored="true"/>
   <field name="creation_time" type="pdate" indexed="true" stored="false" default="NOW"/>
 


### PR DESCRIPTION
This just add an additional unique key for the URI, which is the object store `schema://file_path`. Having this allows queries that return intake type catalogs to open the paths with fsspec.