### PR TITLE
WIP: Make solr config more flexible.

### DIFF
--- a/solr/create_cores.sh
+++ b/solr/create_cores.sh
@@ -4,5 +4,7 @@ for this_core in  $CORE latest;do
     if [ ! -d "/var/solr/data/$this_core" ];then
         precreate-core $this_core
         cp /opt/solr/managed-schema.xml /var/solr/data/$this_core/conf/
+        rm -rf /var/solr/data/$this_core/conf/synonyms.txt
+        ln -s /opt/solr/synonyms.txt /var/solr/data/$this_core/conf/synonyms.txt
     fi
 done

--- a/solr/managed-schema.xml
+++ b/solr/managed-schema.xml
@@ -13,7 +13,7 @@
   <fieldType name="string" class="solr.StrField" sortMissingLast="true"/>
   <fieldType name="booleans" class="solr.BoolField" sortMissingLast="true" multiValued="true"/>
   <fieldType name="version" class="solr.TextField" >
-    <analyzer>
+  <analyzer>
         <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^v"/>
         <tokenizer class="solr.KeywordTokenizerFactory"/>
     </analyzer>
@@ -23,10 +23,15 @@
     <analyzer type="index">
       <tokenizer class="solr.KeywordTokenizerFactory"/>
       <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+      <filter class="solr.FlattenGraphFilterFactory"/>
     </analyzer>
+
     <analyzer type="query">
       <tokenizer class="solr.KeywordTokenizerFactory"/>
       <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+      <filter class="solr.FlattenGraphFilterFactory"/>
     </analyzer>
   </fieldType>
 
@@ -34,10 +39,14 @@
     <analyzer type="index">
       <tokenizer class="solr.KeywordTokenizerFactory"/>
       <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+      <filter class="solr.FlattenGraphFilterFactory"/>
     </analyzer>
     <analyzer type="query">
       <tokenizer class="solr.KeywordTokenizerFactory"/>
       <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+      <filter class="solr.FlattenGraphFilterFactory"/>
     </analyzer>
   </fieldType>
 
@@ -51,6 +60,7 @@
   <!-- we need this to search for latest version.
   If not it won't work for entries not being versioned at all -->
   <field name="version" type="version" stored="false" indexed="true" default="-1"/>
+  <!-- Define the standard facet names -->
   <field name="file_no_version" type="string" stored="false" indexed="true"/>
   <field name="fs_type" type="string" indexed="true" stored="false" default="posix"/>
   <field name="project" type="text_general" stored="true" indexed="true" multiValued="true"/>
@@ -64,26 +74,61 @@
   <field name="ensemble" type="text_general" stored="true" indexed="true" multiValued="true"/>
   <field name="variable" type="text_general" stored="true" indexed="true" multiValued="true"/>
   <field name="dataset" type="text_general" stored="true" indexed="true" multiValued="true"/>
-  <field name="file_name" type="text_general" stored="true" indexed="true" multiValued="true"/>
+  <field name="file_name" type="string" stored="true" indexed="true" multiValued="true"/>
   <field name="time" type="rdate" stored="true" indexed="true"/>
-  <!-- now lets define extra facets that are not displayd by default. -->
-  <field name="mip_era" type="extra_facet" stored="true" indexed="true" multiValued="true" />
-  <field name="activity_id" type="extra_facet" stored="true" indexed="true" multiValued="true" />
-  <field name="institution_id" type="extra_facet" stored="true" indexed="true" multiValued="true" />
-  <field name="source_id" type="extra_facet" stored="true" indexed="true" multiValued="true" />
-  <field name="experiment_id" type="extra_facet" stored="true" indexed="true" multiValued="true" />
-  <field name="member_id" type="extra_facet" stored="true" indexed="true" multiValued="true" />
-  <field name="table_id" type="extra_facet" stored="true" indexed="true" multiValued="true" />
+  <field name="time_aggregation" type="text_general" stored="true" indexed="true" multiValued="true" default="avg"/>
+
+  <!-- define alias facet names -->
+  <field name="activity_id" type="extra_facet" stored="true" indexed="true" multiValued="true"/>
+  <copyField dest="activity_id" source="product"/>
+
+  <field name="domain" type="extra_facet" stored="true" indexed="true" multiValued="true"/>
+  <copyField dest="domain" source="product"/>
+
+  <field name="experiment_id" type="extra_facet" stored="true" indexed="true" multiValued="true"/>
+  <copyField dest="experiment_id" source="experiment"/>
+
   <field name="frequency" type="extra_facet" stored="true" indexed="true" multiValued="true"/>
-  <field name="variable_id" type="extra_facet" stored="true" indexed="true" multiValued="true" />
-  <field name="grid_label" type="extra_facet" stored="true" indexed="true" multiValued="true" />
-  <field name="domain" type="extra_facet" stored="true" indexed="true" multiValued="true" />
+  <copyField dest="frequency" source="time_frequency"/>
+
+  <field name="institution" type="extra_facet" stored="true" indexed="true" multiValued="true"/>
+  <copyField dest="institution" source="institute"/>
+
+  <field name="institution_id" type="extra_facet" stored="true" indexed="true" multiValued="true"/>
+  <copyField dest="institution_id" source="institute"/>
+
+  <field name="mip_era" type="extra_facet" stored="true" indexed="true" multiValued="true"/>
+  <copyField dest="mip_era" source="project"/>
+
+  <field name="member_id" type="extra_facet" stored="true" indexed="true" multiValued="true"/>
+  <copyField dest="member_id" source="ensemble"/>
+
+  <field name="model_id" type="extra_facet" stored="true" indexed="true" multiValued="true"/>
+  <copyField dest="model_id" source="model"/>
+
+  <field name="simulation_id" type="extra_facet" stored="true" indexed="true" multiValued="true"/>
+  <copyField dest="simulation_id" source="experiment"/>
+
+  <field name="source_id" type="extra_facet" stored="true" indexed="true" multiValued="true"/>
+  <copyField dest="source_id" source="model"/>
+
+  <field name="table_id" type="extra_facet" stored="true" indexed="true" multiValued="true"/>
+  <copyField dest="table_id" source="cmor_table"/>
+
+  <field name="time_reduction" type="extra_facet" stored="true" indexed="true" multiValued="true"/>
+  <copyField dest="time_reduction" source="time_aggregation"/>
+
+  <field name="variable_id" type="extra_facet" stored="true" indexed="true" multiValued="true"/>
+  <copyField dest="variable_id" source="variable"/>
+
+  <!-- define extra facet name that are not displayd by default. -->
   <field name="driving_model" type="extra_facet" stored="true" indexed="true" multiValued="true" />
   <field name="rcm_name" type="extra_facet" stored="true" indexed="true" multiValued="true" />
   <field name="rcm_version" type="extra_facet" stored="true" indexed="true" multiValued="true" />
-  <field name="level_type" type="extra_facet" stored="true" indexed="true" multiValued="true" />
-  <field name="time_reduction" type="extra_facet" stored="true" indexed="true" multiValued="true" />
-  <field name="simulation_id" type="extra_facet" stored="true" indexed="true" multiValued="true" />
-  <field name="grid_id" type="extra_facet" stored="true" indexed="true" multiValued="true" />
-  <field name="format" type="extra_facet" stored="true" indexed="true" multiValued="true" />
+  <field name="grid_label" type="extra_facet" stored="true" indexed="true" multiValued="true" default="gn"/>
+  <field name="grid_id" type="extra_facet" stored="true" indexed="true" multiValued="true"/>
+  <field name="level_type" type="extra_facet" stored="true" indexed="true" multiValued="true" default="2d"/>
+  <field name="format" type="extra_facet" stored="true" indexed="true" multiValued="true" default="nc"/>
+
+
 </schema>

--- a/solr/synonyms.txt
+++ b/solr/synonyms.txt
@@ -1,0 +1,16 @@
+minute, minutes, min, 1minpt, pt1min, minute_pt, pt_minutes => 1min
+2minute, 2minutes, 2min, 2minpt, pt2min, minute2_pt, pt_2minutes => 2min
+5minute, 5minutes, 5min, 5minpt, pt5min, minute5_pt, pt_5minutes => 5min
+15minute, 15minutes, 15min, 15minpt, pt15min, minute15_pt, pt_15minutes => 15min
+hour, hours, hr, 1hrpt, pt1hr, hour_pt, pt_hours => 1hr
+3hour, 3hours, 3hr, 3hrpt, pt3hr, hour3_pt, pt_3hours => 3hr
+6hour, 6hours, 6hr, 6hrpt, pt6hr, hour6_pt, pt_6hours => 6hr
+12hour, 12hours, 12hr, 12hrpt, pt12hr, hour12_pt, pt_12hours => 12hr
+23hour, 23hours, 23hr, 23hrpt, pt23hr, hour23_pt, pt_23hours => 23hr
+day, days, dy, 1daypt, pt1day, day_pt, pt_days => 1day
+12day, 12days, 12dy, 12daypt, pt12day, day12_pt, pt_12days => 12day
+7day, sems, sm, 7daypt, pt7day, sem_pt, pt_sems => sem
+1mon, months, mo, 1monpt, pt1mon, mon_pt, pt_months, monc, monclim => mon
+1yr, yrc, yrclim, yearly, year, yearc, yearclim, 1y => yr
+decc, decclim => dec
+fix, fixed => fx


### PR DESCRIPTION
With this, the solr core should become more flexible. This does:

  - introduces synonyms used at index and query time to map certain facet values (for now I have defined synonymous time frequencies).
  - defines facet names that are alias of our freva facets so users can query and look up facets without using our facet schema, but the schema they might be used to like cordex, cmip6 etc
  
  There might be room for improvement. Because the solr core could get really big and we would need more synonyms.
  
  Here is an example:
  
  
   ```

freva databrowser --facet product
activity_id: cmip,eur-11

freva databrowser --facet domain
domain: cmip,eur-11

freva databrowser --facet activity_id 
activity_id: cmip,eur-11


freva databrowser frequency=3hour
/home/wilfred/workspace/solr-data-crawler/data/model/regional/cordex/output/EUR-11/GERICS/NCC-NorESM1-M/rcp85/r1i1p1/GERICS-REMO2015/v1/3hr/pr/v20181212/pr_EUR-11_NCC-NorESM1-M_rcp85_r1i1p1_GERICS-REMO2015_v2_3hr_200701020130-200701020430.nc
freva databrowser time_frequency=3hr
/home/wilfred/workspace/solr-data-crawler/data/model/regional/cordex/output/EUR-11/GERICS/NCC-NorESM1-M/rcp85/r1i1p1/GERICS-REMO2015/v1/3hr/pr/v20181212/pr_EUR-11_NCC-NorESM1-M_rcp85_r1i1p1_GERICS-REMO2015_v2_3hr_200701020130-200701020430.nc
```
