### PR TITLE
Add a new username facet.

### DIFF
--- a/solr/managed-schema.xml
+++ b/solr/managed-schema.xml
@@ -87,6 +87,7 @@
   <field name="level_type" type="extra_facet" stored="true" indexed="true" multiValued="true" default="2d"/>
   <field name="rcm_name" type="extra_facet" stored="true" indexed="true" multiValued="true" />
   <field name="rcm_version" type="extra_facet" stored="true" indexed="true" multiValued="true" />
+  <field name="user" type="extra_facet" stored="true" indexed="true" multiValued="false" />
   <!-- define the future dataset definition. -->
   <field name="future" type="string" stored="true" indexed="false" multiValued="false" default=""/>
   <field name="future_id" type="string" stored="true" indexed="false" multiValued="false" default="-1"/>

--- a/solr/synonyms.txt
+++ b/solr/synonyms.txt
@@ -38,3 +38,4 @@ pt, point, instant, inst, instantaneous => inst
 agg, aggregated, accumulated, sum  => acc
 max, maximum => max
 min, minimum => min
+usr, user_name, username => user


### PR DESCRIPTION
## A new user facet

With the user facet, users can seamlessly index their project data under their own namespace within Solr. This change not only simplifies data management but also allows for easy indexing of intake-esm catalogue files. All catalogue entries can be grouped under theuser` facet, ensuring they are distinct from the main metadata collection and eliminating any risk of interference.