### PR TITLE
MySQL -> MariaDB + Apache Solr capitialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,24 +3,24 @@
 This repository holds all definitions for Docker images to create all services
 that are needed to run Freva in production and development mode.
 
-Any changes to the configurations like MySQL table definitions or the apache
-solr managed_schema.xml file should be done here.
+Any changes to the configurations like MariaDB table definitions or the Apache
+Solr managed_schema.xml file should be done here.
 
 An automated pipeline builds the images and pushes them to the DKRZ registry
 where they can be pulled for usage in production or development mode.
 
 ## Using the config files when creating images
 
-Usage of the configurations within the docker solr and MySQL containers should
+Usage of the configurations within the Solr and MariaDB containers should
 be realised by adding the files via *volumes* to the container during creation.
 
-For MySQL this could be:
+For MariaDB this could be:
 
 ```
 docker run -v path/to/freva-service-config/mysql/create-users.sql:/docker-entrypoint-initdb.d/001_create_users.sql:ro
 ```
 
-For apache solr two files are need:
+For Apache Solr two files are need:
 
 ```
 docker run -v path/to/freva-service-config/solr/managed_schema.xml:/opt/solr/managed_schema.xml:ro \
@@ -31,20 +31,20 @@ If you need a simple backup functionality, you can add the `daily_backup.sh`
 script in the same manner.
 
 Setting up the volumes as outlined above will instruct the containers to
-automatically creating new MySQL tables (if not existing)
-and solr cores (if not existing).
+automatically creating new MariaDB tables (if not existing) and Solr cores
+(if not existing).
 
 The following environment variables should be
-considered when starting the **MySQL** container:
+considered when starting the **MariaDB** container:
 
-- `MYSQL_ROOT_PASSWORD`: MySQL root password for the container.
-- `MYSQL_USER`: 'normal' MySQL user, Freva will be connecting to the DB with
+- `MARIADB_ROOT_PASSWORD`: MariaDB root password for the container.
+- `MARIADB_USER`: 'normal' MariaDB user, Freva will be connecting to the DB with
   this user name.
-- `MYSQL_PASSWORD`: password for the 'normal' MySQL user name.
-- `MYSQL_DATABASE`: the name of the database where all Freva related tables
+- `MARIADB_PASSWORD`: password for the 'normal' MariaDB user name.
+- `MARIADB_DATABASE`: the name of the database where all Freva related tables
   are stored.
 
-For the **apache solr** container consider the following environment variables:
+For the **Apache Solr** container consider the following environment variables:
 
 - `CORE`: name of the standard core holding information about files (default:
    file)


### PR DESCRIPTION
MySQL isnt' the same as MariaDB, and since MariaDB is being used, use its name.

Capitalize Apache Solr since its a brand name.