### PR TITLE
Add redis config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,27 @@
 # Freva services
 
-This repository holds all definitions for Docker images to create all services
-that are needed to run Freva in production and development mode.
+This repository holds all definitions for Docker images to create services
+that are needed to run Freva in production and development mode. Currently
+those services are:
 
-Any changes to the configurations like MariaDB table definitions or the Apache
-Solr managed_schema.xml file should be done here.
+- MariaDB
+- Apache Solr
+- Redis
 
-An automated pipeline builds the images and pushes them to the DKRZ registry
-where they can be pulled for usage in production or development mode.
+Any changes to the configurations like MariaDB table definitions, Apache
+Solr managed_schema.xml file or Redis startup script should be done here.
 
 ## Using the config files when creating images
 
-Usage of the configurations within the Solr and MariaDB containers should
+Usage of the configurations within the Solr, MariaDB and Redis containers should
 be realised by adding the files via *volumes* to the container during creation.
 
-For MariaDB this could be:
 
-```
+### MariaDB
+
+```console
 docker run -v path/to/freva-service-config/mysql/create-users.sql:/docker-entrypoint-initdb.d/001_create_users.sql:ro
 ```
-
-For Apache Solr two files are need:
-
-```
-docker run -v path/to/freva-service-config/solr/managed_schema.xml:/opt/solr/managed_schema.xml:ro \
-       path/to/freva-service-config/sorl/create_cores.sh:/docker-entrypoint-initdb.d/create_cores.sh:ro
-```
-
-If you need a simple backup functionality, you can add the `daily_backup.sh`
-script in the same manner.
-
-Setting up the volumes as outlined above will instruct the containers to
-automatically creating new MariaDB tables (if not existing) and Solr cores
-(if not existing).
 
 The following environment variables should be
 considered when starting the **MariaDB** container:
@@ -44,6 +33,15 @@ considered when starting the **MariaDB** container:
 - `MARIADB_DATABASE`: the name of the database where all Freva related tables
   are stored.
 
+### Apache Solr
+
+For Apache Solr two files are need:
+
+```console
+docker run -v path/to/freva-service-config/solr/managed_schema.xml:/opt/solr/managed_schema.xml:ro \
+       path/to/freva-service-config/sorl/create_cores.sh:/docker-entrypoint-initdb.d/create_cores.sh:ro
+```
+
 For the **Apache Solr** container consider the following environment variables:
 
 - `CORE`: name of the standard core holding information about files (default:
@@ -52,7 +50,40 @@ For the **Apache Solr** container consider the following environment variables:
 - `NUM_BACKUPS`: number of backups to keep. See backup for more details.
 
 
-## Backup of data
+### Redis
+A secure Redis instance using ACL's and TLS connections can be set up using
+the following docker command:
+
+```console
+docker run -v path/to/freva-service-config/redis/redis-cmd.sh:/usr/local/bin/redis-cmd:z \
+       path/to/tls-certs:/certs redis:latest /usr/local/bin/redis-cmd
+```
+
+The following environment variables are considered by the startup script:
+
+- `REDIS_USERNAME`: user name of the redis db user
+- `REDIS_PASSWORD`: password for the redis db user
+- `REDIS_LOGLEVEL`: redis log level
+- `REDIS_SSL_CERTFILE`: path to the ssl cert file (should be in /cert)
+- `REDIS_SSL_KEYFILE`: path to the ssl key file
+
+> **Note:** The above environment variables are optional, if for example you do
+            not set the `REDIS_USERNAME` and `REDIS_PASSWORD` the server will
+            be started using the default redis db user without password
+            protection. The same applies for TLS certificates. If you choose
+            none, none will be used. Once you've chosen usernames, passwords
+            and certificates make sure this information client(s) is passed
+            on to all clients making connections to the server.
+
+### Backup of data
+If you need a simple backup functionality, you can add the `daily_backup.sh`
+script in the same manner.
+
+Setting up the volumes as outlined above will instruct the containers to
+automatically creating new MariaDB tables (if not existing) and Solr cores
+(if not existing).
+
+
 If you added the `daily_backup.sh` files via a volume to the container you can
 setup simple crontab to create backups on the *host* machine running
 the container. A simple crontab example could like like this.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ those services are:
 - Redis
 
 Any changes to the configurations like MariaDB table definitions, Apache
-Solr managed_schema.xml file or Redis startup script should be done here.
+Solr `managed_schema.xml` file or Redis startup script should be done here.
 
 ## Using the config files when creating images
 
@@ -70,10 +70,10 @@ The following environment variables are considered by the startup script:
 > **Note:** The above environment variables are optional, if for example you do
             not set the `REDIS_USERNAME` and `REDIS_PASSWORD` the server will
             be started using the default redis db user without password
-            protection. The same applies for TLS certificates. If you choose
+            protection. The same applies to TLS certificates. If you choose
             none, none will be used. Once you've chosen usernames, passwords
-            and certificates make sure this information client(s) is passed
-            on to all clients making connections to the server.
+            and/or certificates make sure this information is passed
+            on to the client(s) making connections to the server.
 
 ### Backup of data
 If you need a simple backup functionality, you can add the `daily_backup.sh`

--- a/mysql/daily_backup.sh
+++ b/mysql/daily_backup.sh
@@ -12,4 +12,3 @@ for file in $(ls ${BACKUP_DIR}/backup-*.sql.gz);do
     fi
 done
 mariadb-dump -u root -h localhost -p"${MYSQL_ROOT_PASSWORD}" --all-databases | gzip -c -9 -q > $backup_f
-chown mysql:mysql ${backup_f}

--- a/redis/redis-cmd.sh
+++ b/redis/redis-cmd.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# Set the ACL of the redis instance
+# Strip any rights from the redis default user.
+echo "user default off -@all" > /tmp/redis.conf
+REDIS_PASSWORD="${REDIS_PASSWORD:+>$REDIS_PASSWORD}"
+
+## Add only a selection of user rights, if no user was passed via env use the default user same for password
+echo "user ${REDIS_USERNAME:-default} on +@all -@admin -@dangerous +flushdb ~* &* ${REDIS_PASSWORD:-nopass}" >> /tmp/redis.conf
+
+# Enable sys logging, default notice level
+echo "loglevel ${REDIS_LOGLEVEL:-notice}" >> /tmp/redis.conf
+echo "syslog-enabled yes" >> /tmp/redis.conf
+
+# Check if we have TLS encryption and enable it we have one.
+if [ -f "$REDIS_SSL_CERTFILE" ] && [ -f "$REDIS_SSL_KEYFILE" ];then
+    echo "port 0" >> /tmp/redis.conf
+    echo "tls-port 6379" >> /tmp/redis.conf
+    echo "tls-cert-file $REDIS_SSL_CERTFILE" >> /tmp/redis.conf
+    echo "tls-key-file $REDIS_SSL_KEYFILE" >> /tmp/redis.conf
+    echo "tls-ca-cert-file $REDIS_SSL_CERTFILE" >> /tmp/redis.conf
+fi
+cat /tmp/redis.conf
+redis-server /tmp/redis.conf

--- a/redis/redis-cmd.sh
+++ b/redis/redis-cmd.sh
@@ -6,7 +6,7 @@ echo "user default off -@all" > /tmp/redis.conf
 REDIS_PASSWORD="${REDIS_PASSWORD:+>$REDIS_PASSWORD}"
 
 ## Add only a selection of user rights, if no user was passed via env use the default user same for password
-echo "user ${REDIS_USERNAME:-default} on +@all -@admin -@dangerous +flushdb ~* &* ${REDIS_PASSWORD:-nopass}" >> /tmp/redis.conf
+echo "user ${REDIS_USERNAME:-default} on +@all ~* &* ${REDIS_PASSWORD:-nopass}" >> /tmp/redis.conf
 
 # Enable sys logging, default notice level
 echo "loglevel ${REDIS_LOGLEVEL:-notice}" >> /tmp/redis.conf


### PR DESCRIPTION
Since the freva-web and the freva rest API will both be using redis I figured we might just add a redis startup script here.

The startup script set's ACL's (if username and passwd are set via env variables) and/or uses TLS certs for secure connection.

Since this is optional it is also possible to leave the connection unprotected and passwordless with the default user.
Which is default case in redis. This can be quite nasty,  since this is the case in our frva-web instance we also might want to think of at least setting ACL's. @Karinon any thoughts on this?