### PR TITLE
Add homedir attribute

### DIFF
--- a/keycloak/import/realm-export.json
+++ b/keycloak/import/realm-export.json
@@ -1,6 +1,8 @@
 {
   "id": "dcadb9c7-7134-49d4-ae81-0866e4d43477",
   "realm": "freva",
+  "displayName": "Freva Test",
+  "displayNameHtml": "",
   "notBefore": 0,
   "defaultSignatureAlgorithm": "RS256",
   "revokeRefreshToken": false,
@@ -31,8 +33,8 @@
   "registrationEmailAsUsername": false,
   "rememberMe": false,
   "verifyEmail": false,
-  "loginWithEmailAllowed": true,
-  "duplicateEmailsAllowed": false,
+  "loginWithEmailAllowed": false,
+  "duplicateEmailsAllowed": true,
   "resetPasswordAllowed": false,
   "editUsernameAllowed": false,
   "bruteForceProtected": false,
@@ -594,7 +596,9 @@
       "publicClient": true,
       "frontchannelLogout": false,
       "protocol": "openid-connect",
-      "attributes": {},
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
       "authenticationFlowBindingOverrides": {},
       "fullScopeAllowed": false,
       "nodeReRegistrationTimeout": 0,
@@ -632,7 +636,9 @@
       "publicClient": false,
       "frontchannelLogout": false,
       "protocol": "openid-connect",
-      "attributes": {},
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
       "authenticationFlowBindingOverrides": {},
       "fullScopeAllowed": false,
       "nodeReRegistrationTimeout": 0,
@@ -680,6 +686,7 @@
       "protocol": "openid-connect",
       "attributes": {
         "oidc.ciba.grant.enabled": "false",
+        "post.logout.redirect.uris": "+",
         "oauth2.device.authorization.grant.enabled": "true",
         "backchannel.logout.session.required": "true",
         "backchannel.logout.revoke.offline.tokens": "false"
@@ -691,6 +698,7 @@
         "web-origins",
         "acr",
         "address",
+        "openid",
         "roles",
         "profile",
         "email"
@@ -721,7 +729,9 @@
       "publicClient": false,
       "frontchannelLogout": false,
       "protocol": "openid-connect",
-      "attributes": {},
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
       "authenticationFlowBindingOverrides": {},
       "fullScopeAllowed": false,
       "nodeReRegistrationTimeout": 0,
@@ -879,7 +889,8 @@
           "config": {
             "id.token.claim": "true",
             "introspection.token.claim": "true",
-            "access.token.claim": "true"
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
           }
         }
       ]
@@ -963,10 +974,13 @@
           "protocolMapper": "oidc-usermodel-attribute-mapper",
           "consentRequired": false,
           "config": {
+            "aggregate.attrs": "false",
             "introspection.token.claim": "true",
+            "multivalued": "false",
             "userinfo.token.claim": "true",
             "user.attribute": "profile",
             "id.token.claim": "true",
+            "lightweight.claim": "false",
             "access.token.claim": "true",
             "claim.name": "profile",
             "jsonType.label": "String"
@@ -1046,6 +1060,25 @@
             "id.token.claim": "true",
             "access.token.claim": "true",
             "claim.name": "middle_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c724e34c-b6ec-4430-ab26-0f66c6aafc9d",
+          "name": "home",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "aggregate.attrs": "false",
+            "introspection.token.claim": "true",
+            "multivalued": "false",
+            "userinfo.token.claim": "true",
+            "user.attribute": "home",
+            "id.token.claim": "true",
+            "lightweight.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "home",
             "jsonType.label": "String"
           }
         },
@@ -1275,6 +1308,7 @@
           "config": {
             "introspection.token.claim": "true",
             "multivalued": "true",
+            "userinfo.token.claim": "true",
             "user.attribute": "foo",
             "id.token.claim": "true",
             "access.token.claim": "true",
@@ -1308,6 +1342,18 @@
       "attributes": {
         "consent.screen.text": "${offlineAccessScopeConsentText}",
         "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "eb1979ca-06d1-4e94-96ae-4fc8a1e079e6",
+      "name": "openid",
+      "description": "Display user info",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "gui.order": "",
+        "consent.screen.text": ""
       }
     },
     {
@@ -1349,7 +1395,8 @@
     "email",
     "roles",
     "web-origins",
-    "acr"
+    "acr",
+    "openid"
   ],
   "defaultOptionalClientScopes": [
     "offline_access",
@@ -1408,13 +1455,13 @@
         "config": {
           "allowed-protocol-mapper-types": [
             "saml-role-list-mapper",
+            "oidc-address-mapper",
+            "oidc-full-name-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
             "saml-user-property-mapper",
             "oidc-usermodel-property-mapper",
-            "saml-user-attribute-mapper",
-            "oidc-full-name-mapper",
-            "oidc-sha256-pairwise-sub-mapper",
-            "oidc-usermodel-attribute-mapper",
-            "oidc-address-mapper"
+            "saml-user-attribute-mapper"
           ]
         }
       },
@@ -1446,14 +1493,14 @@
         "subComponents": {},
         "config": {
           "allowed-protocol-mapper-types": [
-            "oidc-address-mapper",
-            "saml-user-property-mapper",
-            "oidc-usermodel-attribute-mapper",
-            "saml-user-attribute-mapper",
-            "oidc-usermodel-property-mapper",
             "oidc-sha256-pairwise-sub-mapper",
+            "oidc-address-mapper",
             "saml-role-list-mapper",
-            "oidc-full-name-mapper"
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-property-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-full-name-mapper",
+            "oidc-usermodel-property-mapper"
           ]
         }
       },
@@ -1504,10 +1551,10 @@
                 "is.mandatory.in.ldap": [
                   "false"
                 ],
-                "read.only": [
+                "always.read.value.from.ldap": [
                   "true"
                 ],
-                "always.read.value.from.ldap": [
+                "read.only": [
                   "true"
                 ],
                 "user.model.attribute": [
@@ -1527,11 +1574,11 @@
                 "is.mandatory.in.ldap": [
                   "true"
                 ],
-                "read.only": [
-                  "true"
-                ],
                 "always.read.value.from.ldap": [
                   "false"
+                ],
+                "read.only": [
+                  "true"
                 ],
                 "user.model.attribute": [
                   "username"
@@ -1573,14 +1620,46 @@
                 "is.mandatory.in.ldap": [
                   "false"
                 ],
-                "always.read.value.from.ldap": [
+                "read.only": [
                   "true"
                 ],
-                "read.only": [
+                "always.read.value.from.ldap": [
                   "true"
                 ],
                 "user.model.attribute": [
                   "createTimestamp"
+                ]
+              }
+            },
+            {
+              "id": "1a9e443c-e77f-4c88-92d1-48467e27ddf5",
+              "name": "home",
+              "providerId": "user-attribute-ldap-mapper",
+              "subComponents": {},
+              "config": {
+                "ldap.attribute": [
+                  "description"
+                ],
+                "attribute.default.value": [
+                  "/tmp/guest"
+                ],
+                "is.mandatory.in.ldap": [
+                  "true"
+                ],
+                "attribute.force.default": [
+                  "true"
+                ],
+                "is.binary.attribute": [
+                  "false"
+                ],
+                "read.only": [
+                  "true"
+                ],
+                "always.read.value.from.ldap": [
+                  "true"
+                ],
+                "user.model.attribute": [
+                  "home"
                 ]
               }
             },
@@ -1596,10 +1675,10 @@
                 "is.mandatory.in.ldap": [
                   "true"
                 ],
-                "always.read.value.from.ldap": [
+                "read.only": [
                   "true"
                 ],
-                "read.only": [
+                "always.read.value.from.ldap": [
                   "true"
                 ],
                 "user.model.attribute": [
@@ -1637,16 +1716,16 @@
             "false"
           ],
           "fullSyncPeriod": [
-            "-1"
+            "60"
           ],
           "startTls": [
             "false"
           ],
-          "connectionPooling": [
-            "false"
-          ],
           "usersDn": [
             "ou=users,dc=example,dc=com"
+          ],
+          "connectionPooling": [
+            "false"
           ],
           "cachePolicy": [
             "DEFAULT"
@@ -1660,20 +1739,20 @@
           "enabled": [
             "true"
           ],
+          "changedSyncPeriod": [
+            "60"
+          ],
           "bindCredential": [
             "admin_password"
           ],
           "bindDn": [
             "cn=admin,dc=example,dc=com"
           ],
-          "changedSyncPeriod": [
-            "-1"
-          ],
           "usernameLDAPAttribute": [
             "uid"
           ],
           "lastSync": [
-            "1718669079"
+            "1723020373"
           ],
           "vendor": [
             "other"
@@ -2425,13 +2504,19 @@
   "firstBrokerLoginFlow": "first broker login",
   "attributes": {
     "cibaBackchannelTokenDeliveryMode": "poll",
-    "cibaExpiresIn": "120",
     "cibaAuthRequestedUserHint": "login_hint",
-    "oauth2DeviceCodeLifespan": "600",
+    "clientOfflineSessionMaxLifespan": "0",
     "oauth2DevicePollingInterval": "5",
-    "parRequestUriLifespan": "60",
+    "clientSessionIdleTimeout": "0",
+    "clientOfflineSessionIdleTimeout": "0",
     "cibaInterval": "5",
-    "realmReusableOtpCode": "false"
+    "realmReusableOtpCode": "false",
+    "cibaExpiresIn": "120",
+    "oauth2DeviceCodeLifespan": "600",
+    "parRequestUriLifespan": "60",
+    "clientSessionMaxLifespan": "0",
+    "frontendUrl": "",
+    "acr.loa.map": "{}"
   },
   "keycloakVersion": "24.0.4",
   "userManagedAccessAllowed": false,

--- a/keycloak/users.ldif
+++ b/keycloak/users.ldif
@@ -9,7 +9,7 @@ sn: Doe
 uid: johndoe
 mail: john@example.com
 userPassword: johndoe123
-
+description: /home/johndoe
 
 dn: uid=janedoe,ou=users,dc=example,dc=com
 objectClass: inetOrgPerson
@@ -18,6 +18,7 @@ sn: Doe
 uid: janedoe
 mail: jane@example.com
 userPassword: janedoe123
+description: /home/janedoe
 
 dn: uid=alicebrown,ou=users,dc=example,dc=com
 objectClass: inetOrgPerson
@@ -26,6 +27,7 @@ sn: Brown
 uid: alicebrown
 mail: alice@example.com
 userPassword: alicebrown123
+description: /home/alicebrown
 
 dn: uid=bobsmith,ou=users,dc=example,dc=com
 objectClass: inetOrgPerson
@@ -34,6 +36,7 @@ sn: Smith
 uid: bobsmith
 mail: bob@example.com
 userPassword: bobsmith123
+description: /home/bobsmith
 
 dn: uid=lisajones,ou=users,dc=example,dc=com
 objectClass: inetOrgPerson
@@ -42,3 +45,4 @@ sn: Jones
 uid: lisajones
 mail: lisa@example.com
 userPassword: lisajones123
+description: /home/lisajones


### PR DESCRIPTION
Sorry I need to open this again.

This adds a home directory attribute to the user information in keycloak. The home directory comes from ldap - just like in the DRKZ ldap.

The only difference is that I couldn't get the posixAccout ldap class working in the dev ldap so I decided to abuse the description attribute. the description attribute is then mapped to the home attribute in keycloak. 

I need this for freva-web, as freva-web needs information on user home directories. Not sure if that's needed though.