### PR TITLE
adding bbox to solr managed schema and mongo init 

### DIFF
--- a/mongo/mongo-userdata-init.js
+++ b/mongo/mongo-userdata-init.js
@@ -61,7 +61,15 @@ db.createCollection("user_data", {
             bsonType: "string",
             description: "File name without version."
           },
-    
+          "bbox": {
+            bsonType: "array",
+            minItems: 4,
+            maxItems: 4,
+            items: {
+              bsonType: "double"
+            },
+            description: "Bounding box coordinates [west, south, east, north] in degrees"
+          },
           // Standard Facet Fields (Multivalued)
           "cmor_table": multiValuedStringField("Array of CMOR tables or a single string."),
           "experiment": multiValuedStringField("Array of experiments or a single string."),

--- a/solr/managed-schema.xml
+++ b/solr/managed-schema.xml
@@ -13,6 +13,7 @@
   <fieldType name="string" class="solr.StrField" sortMissingLast="true"/>
   <fieldType name="booleans" class="solr.BoolField" sortMissingLast="true" multiValued="true"/>
   <fieldType name="version" class="solr.TextField" >
+  <fieldType name="bbox" class="solr.BBoxField" geo="false" numberType="pdouble" units="degrees"/>
   <analyzer>
         <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^v"/>
         <tokenizer class="solr.KeywordTokenizerFactory"/>
@@ -78,6 +79,7 @@
   <field name="time" type="rdate" stored="true" indexed="true"/>
   <field name="time_aggregation" type="text_general" stored="true" indexed="true" multiValued="true" default="mean"/>
   <field name="time_frequency" type="text_general" stored="true" indexed="true" multiValued="true"/>
+  <field name="bbox" type="bbox" stored="true" indexed="true" multiValued="false"/>
 
   <!-- define extra facet name that are not displayd by default. -->
   <field name="dataset" type="extra_facet" stored="true" indexed="true" multiValued="false"/>

--- a/solr/managed-schema.xml
+++ b/solr/managed-schema.xml
@@ -13,14 +13,14 @@
   <fieldType name="string" class="solr.StrField" sortMissingLast="true"/>
   <fieldType name="booleans" class="solr.BoolField" sortMissingLast="true" multiValued="true"/>
   <fieldType name="version" class="solr.TextField" >
-  <fieldType name="bbox" class="solr.SpatialRecursivePrefixTreeFieldType" normWrapLongitude="true"
-             geo="true" distErrPct="0.025" maxDistErr="0.001" distanceUnits="degrees" />
+
   <analyzer>
         <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^v"/>
         <tokenizer class="solr.KeywordTokenizerFactory"/>
     </analyzer>
   </fieldType>
-
+  <fieldType name="bbox" class="solr.SpatialRecursivePrefixTreeFieldType" normWrapLongitude="true"
+             geo="true" distErrPct="0.025" maxDistErr="0.001" distanceUnits="degrees" />
   <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100" multiValued="true">
     <analyzer type="index">
       <tokenizer class="solr.KeywordTokenizerFactory"/>

--- a/solr/managed-schema.xml
+++ b/solr/managed-schema.xml
@@ -13,7 +13,7 @@
   <fieldType name="string" class="solr.StrField" sortMissingLast="true"/>
   <fieldType name="booleans" class="solr.BoolField" sortMissingLast="true" multiValued="true"/>
   <fieldType name="version" class="solr.TextField" >
-  <fieldType name="bbox" class="solr.BBoxField" geo="false" numberType="pdouble" units="degrees"/>
+  <fieldType name="bbox" class="solr.BBoxField" geo="false" numberType="pdoubles"/>
   <analyzer>
         <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^v"/>
         <tokenizer class="solr.KeywordTokenizerFactory"/>

--- a/solr/managed-schema.xml
+++ b/solr/managed-schema.xml
@@ -13,7 +13,8 @@
   <fieldType name="string" class="solr.StrField" sortMissingLast="true"/>
   <fieldType name="booleans" class="solr.BoolField" sortMissingLast="true" multiValued="true"/>
   <fieldType name="version" class="solr.TextField" >
-  <fieldType name="bbox" class="solr.BBoxField" geo="false" numberType="pdoubles"/>
+  <fieldType name="bbox" class="solr.SpatialRecursivePrefixTreeFieldType" normWrapLongitude="true"
+             geo="true" distErrPct="0.025" maxDistErr="0.001" distanceUnits="degrees" />
   <analyzer>
         <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^v"/>
         <tokenizer class="solr.KeywordTokenizerFactory"/>
@@ -79,7 +80,7 @@
   <field name="time" type="rdate" stored="true" indexed="true"/>
   <field name="time_aggregation" type="text_general" stored="true" indexed="true" multiValued="true" default="mean"/>
   <field name="time_frequency" type="text_general" stored="true" indexed="true" multiValued="true"/>
-  <field name="bbox" type="bbox" stored="true" indexed="true" multiValued="false"/>
+  <field name="bbox" type="bbox" multiValued="true" indexed="true" stored="true"/>
 
   <!-- define extra facet name that are not displayd by default. -->
   <field name="dataset" type="extra_facet" stored="true" indexed="true" multiValued="false"/>


### PR DESCRIPTION
To incorporate the new `bbox` field into Solr for generating a metadata catalog from the Freva NextGen databrowser, we need to first define the field here. Once defined, this parameter will be accessible for metadata generation. Additionally, I’ve updated the `bbox` entry in the `mono` initialization file