### PR TITLE
Opensearch configuration for STAC

### DIFF
--- a/opensearch/opensearch.yml
+++ b/opensearch/opensearch.yml
@@ -7,17 +7,13 @@ discovery.type: single-node
 http.port: 9202
 http.cors.enabled: true
 http.cors.allow-headers: X-Requested-With,Content-Type,Content-Length,Accept,Authorization
-
-path:
-  repo:
-    - /usr/share/opensearch/snapshots
     
 action.auto_create_index: true
 cluster.blocks.create_index: false
 
-cluster.routing.allocation.disk.watermark.low: 95%
-cluster.routing.allocation.disk.watermark.high: 97%
-cluster.routing.allocation.disk.watermark.flood_stage: 98%
+cluster.routing.allocation.disk.watermark.low: 30gb
+cluster.routing.allocation.disk.watermark.high: 8gb
+cluster.routing.allocation.disk.watermark.flood_stage: 4gb
 
 # Security
 plugins.security.disabled: true

--- a/opensearch/opensearch.yml
+++ b/opensearch/opensearch.yml
@@ -1,0 +1,28 @@
+## Cluster Settings
+cluster.name: stac-cluster
+node.name: os01
+network.host: 0.0.0.0
+transport.host: 0.0.0.0
+discovery.type: single-node
+http.port: 9202
+http.cors.enabled: true
+http.cors.allow-headers: X-Requested-With,Content-Type,Content-Length,Accept,Authorization
+
+path:
+  repo:
+    - /usr/share/opensearch/snapshots
+    
+action.auto_create_index: true
+cluster.blocks.create_index: false
+
+cluster.routing.allocation.disk.watermark.low: 95%
+cluster.routing.allocation.disk.watermark.high: 97%
+cluster.routing.allocation.disk.watermark.flood_stage: 98%
+
+# Security
+plugins.security.disabled: true
+plugins.security.ssl.http.enabled: true
+
+
+
+node.max_local_storage_nodes: 3


### PR DESCRIPTION
Since we need a bit of opensearch security configuration for running on both docker and conda for running the STAC API, this PR is simply going to store this configuration in this repo.