### PR TITLE
Add start scripts for conda.

### DIFF
--- a/conda-services/create.sh
+++ b/conda-services/create.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -u -o nounset -o pipefail -o errexit
+
+TEMP_DIR=$(mktemp -d)
+PKG_NAME=freva-rest-server
+PREFIX=${CONDA_PREFIX:-${MAMBA_ROOT_PREFix:-}}
+SERVICES=(mongo mysql solr redis nginx)
+SUFFIXES=(suffix in txt xml sql j2 html gif types)
+
+print_help() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Start the micro services of the Freva RestAPI.
+
+Options:
+  -p, --prefix <name>    Installation Prefix, default: ${PREFIX}
+  -h, --help             Show this help message and exit
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -p|--prefix)
+      export PREFIX="$2"
+      shift 2
+      ;;
+    --prefix=*)
+      export PREFIX="${1#*=}"
+      shift
+      ;;
+    -h|--help)
+      print_help
+      exit 0
+      ;;
+    *)
+      echo "❌ Unknown argument: \$1" >&2
+      print_help
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "${PREFIX}" ];then
+    echo echo "❌ PREFIX must be set via -p or \$CONDA_PREFIX env var" >&2
+    exit 1
+fi
+
+# Define an exit function
+exit_func(){
+    rm -rf $TEMP_DIR
+    exit $1
+}
+
+check_for_git_reop(){
+    for service in ${SERVICES[@]};do
+        if [ ! -f $service/requirements.txt ];then
+            git clone --recursive https://github.com/FREVA-CLINT/freva-service-config.git $TEMP_DIR
+            cd $TEMP_DIR
+            break
+        fi
+    done
+}
+
+# Trap exit signals to ensure cleanup is called
+trap 'exit_func 1' SIGINT SIGTERM ERR
+
+
+# Setup additional configuration
+mkdir -p $PREFIX/etc/profile.d $PREFIX/libexec/$PKG_NAME
+cat <<EOF > $PREFIX/etc/profile.d/freva-rest-server.sh
+    #!/usr/bin/env bash
+set -u
+
+: "\${SERVICE:?SERVICE variable must be set before sourcing this script}"
+
+export DATA_DIR=\${API_DATA_DIR:-$PREFIX/var/$PKG_NAME/\$SERVICE}
+export LOG_DIR=\${API_LOG_DIR:-$PREFIX/var/log/$PKG_NAME/\$SERVICE}
+export CONFIG_DIR=\${API_CONFIG_DIR:-$PREFIX/share/$PKG_NAME/\$SERVICE}
+export USER=\$(whoami)
+
+mkdir -p \$DATA_DIR \$LOG_DIR \$CONFIG_DIR || true
+EOF
+this_dir=$(pwd)
+check_for_git_reop
+for service in "${SERVICES[@]}";do
+    mkdir -p $PREFIX/var/$PKG_NAME/$service
+    mkdir -p $PREFIX/var/log/$PKG_NAME/$service
+    mkdir -p $PREFIX/share/$PKG_NAME/$service/
+    cp $service/init-$service $PREFIX/libexec/$PKG_NAME/
+    for suffix in ${SUFFIXES[@]};do
+        cp $service/*.$suffix $PREFIX/share/$PKG_NAME/$service/ 2> /dev/null || true
+    done
+    rm -f $PREFIX/share/$PKG_NAME/$service/requirements.txt
+    cp docker-scripts/healthchecks.sh $PREFIX/libexec/$PKG_NAME/
+    chmod +x $PREFIX/libexec/$PKG_NAME/*
+done
+
+cat <<EOI > $PREFIX/bin/start-freva-service
+#!/usr/bin/env bash
+# Start services for the freva-rest-api
+#
+set -u -o nounset -o pipefail -o errexit
+supported_services=(${SERVICES[@]})
+
+export SERVICE=\${SERVICE:-}
+print_help() {
+  cat <<EOF
+Usage: $(basename "\$0") [OPTIONS]
+
+Start the micro services of the Freva RestAPI.
+
+Options:
+  -s, --service <name>   Name of the service (\${supported_services[@]})
+  -h, --help             Show this help message and exit
+EOF
+}
+
+while [[ \$# -gt 0 ]]; do
+  case "\$1" in
+    -s|--service)
+      export SERVICE="\$2"
+      shift 2
+      ;;
+    --service=*)
+      export SERVICE="\${1#*=}"
+      shift
+      ;;
+    -h|--help)
+      print_help
+      exit 0
+      ;;
+    "\${supported_services[@]}")
+      export SERVICE=\$1
+      shift
+      ;;
+    *)
+      echo "❌ Unknown argument: \$1" >&2
+      print_help
+      exit 1
+      ;;
+  esac
+done
+
+# Start the selected service
+if [ -z "\$SERVICE" ];then
+    echo "❌ No service specified: \$SERVICE" >&2
+    print_help
+    exit 1
+elif [[ ! " \${supported_services[*]} " =~ " \${SERVICE} " ]];then
+    echo "❌ Unsupported service: \$SERVICE" >&2
+    echo "Supported services are: \${supported_services[*]}" >&2
+    exit 1
+fi
+
+export CONDA_PREFIX=$PREFIX
+export PATH=$PREFIX/bin:$PATH
+SERVICE_SCRIPT=$PREFIX/libexec/$PKG_NAME/init-\$SERVICE
+source $PREFIX/etc/profile.d/freva-rest-server.sh
+trap "rm -rf /tmp/\$SERVICE || true" EXIT
+\$SERVICE_SCRIPT
+EOI
+chmod +x $PREFIX/bin/start-freva-service
+exit_func 0

--- a/conda-services/create.sh
+++ b/conda-services/create.sh
@@ -55,7 +55,7 @@ exit_func(){
 check_for_git_reop(){
     for service in ${SERVICES[@]};do
         if [ ! -f $service/requirements.txt ];then
-            git clone --recursive -b add-conda-recipe https://github.com/FREVA-CLINT/freva-service-config.git $TEMP_DIR
+            git clone --recursive https://github.com/FREVA-CLINT/freva-service-config.git $TEMP_DIR
             cd $TEMP_DIR
             break
         fi

--- a/conda-services/create.sh
+++ b/conda-services/create.sh
@@ -55,7 +55,7 @@ exit_func(){
 check_for_git_reop(){
     for service in ${SERVICES[@]};do
         if [ ! -f $service/requirements.txt ];then
-            git clone --recursive https://github.com/FREVA-CLINT/freva-service-config.git $TEMP_DIR
+            git clone --recursive -b add-conda-recipe https://github.com/FREVA-CLINT/freva-service-config.git $TEMP_DIR
             cd $TEMP_DIR
             break
         fi

--- a/conda-services/create.sh
+++ b/conda-services/create.sh
@@ -158,7 +158,7 @@ export PATH=$PREFIX/bin:$PATH
 SERVICE_SCRIPT=$PREFIX/libexec/$PKG_NAME/init-\$SERVICE
 source $PREFIX/etc/profile.d/freva-rest-server.sh
 trap "rm -rf /tmp/\$SERVICE || true" EXIT
-\$SERVICE_SCRIPT
+exec \$SERVICE_SCRIPT
 EOI
 chmod +x $PREFIX/bin/start-freva-service
 exit_func 0

--- a/mongo/init-mongo
+++ b/mongo/init-mongo
@@ -75,4 +75,4 @@ cleanup
 
 # Final run: start MongoDB with auth and block
 rm -rf "$LOG_DIR"/*
-mongod -f "$CONFIG_DIR/mongod.yaml" --auth --cpu
+exec mongod -f "$CONFIG_DIR/mongod.yaml" --auth --cpu

--- a/mysql/init-mysql
+++ b/mysql/init-mysql
@@ -57,7 +57,7 @@ if [[ -n $MYSQLD_PID ]];then
 fi
 rm -fr $temp_dir
 echo "Init done! Starting mysqld server."
-mysqld \
+exec mysqld \
     --no-defaults \
     --bind-address=0.0.0.0 \
     --datadir=$DATA_DIR \

--- a/nginx/init-nginx
+++ b/nginx/init-nginx
@@ -99,4 +99,4 @@ render_template "$CONFIG_DIR/nginx.j2" "$temp_dir/nginx.conf"
 touch "$LOG_DIR/nginx-error.log" "$LOG_DIR/nginx-access.log"
 chmod -R 1777 $temp_dir $LOG_DIR/*.log
 # Start Nginx
-nginx -e "$LOG_DIR/nginx-error.log" -p "$temp_dir" -c "$temp_dir/nginx.conf" -g "daemon off;"
+exec nginx -e "$LOG_DIR/nginx-error.log" -p "$temp_dir" -c "$temp_dir/nginx.conf" -g "daemon off;"

--- a/nginx/nginx.j2
+++ b/nginx/nginx.j2
@@ -1,4 +1,4 @@
-user {{ env.get("PROXY_USER", "nobody") }};
+user {{ env.get("PROXY_USER", "nobody") }} {{ env.get("PROXY_GRPUP", "") }};
 worker_processes auto;
 error_log stderr info;
 pid {{ env.get("TEMP_DIR", "/tmp") }}/nginx.pid;

--- a/nginx/nginx.j2
+++ b/nginx/nginx.j2
@@ -1,4 +1,4 @@
-user {{ env.get("PROXY_USER", "nobody") }} {{ env.get("PROXY_GRPUP", "") }};
+user {{ env.get("PROXY_USER", "nobody") }} {{ env.get("PROXY_GROUP", "") }};
 worker_processes auto;
 error_log stderr info;
 pid {{ env.get("TEMP_DIR", "/tmp") }}/nginx.pid;

--- a/redis/init-redis
+++ b/redis/init-redis
@@ -78,4 +78,4 @@ echo "pidfile /tmp/redis-server-${REDIS_PORT:-6379}.pid" >> "$REDIS_CONFIG"
 echo "Created Redis with config:"
 cat "$REDIS_CONFIG"
 echo -e "################### START: $(date) ###################\n" >  $LOG_DIR/redis.log
-redis-server "$REDIS_CONFIG"
+exec redis-server "$REDIS_CONFIG"

--- a/redis/init-redis
+++ b/redis/init-redis
@@ -63,7 +63,7 @@ if [ -f "$REDIS_SSL_CERTFILE" ] && [ -f "$REDIS_SSL_KEYFILE" ];then
 port 0
 tls-port ${REDIS_PORT:-6379}
 tls-cert-file $REDIS_SSL_CERTFILE
-tls-key-file $API_REDIS_SSL_KEYFILE
+tls-key-file $REDIS_SSL_KEYFILE
 tls-ca-cert-file $REDIS_SSL_CERTFILE
 tls-protocols TLSv1.3
 EOF

--- a/redis/init-redis
+++ b/redis/init-redis
@@ -12,7 +12,11 @@ JSON="{}"
 
 trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
 
-if [ "${CONFIG_CONTENT:-}" ];then
+if [ "${OVERRIDE:-0}" = "1" ];then
+    rm -r $CONFIG
+fi
+
+if ([ "${CONFIG_CONTENT:-}" ] && [ ! -f "$CONFIG" ]);then
     mkdir -p $CONFIG_DIR
     echo "$CONFIG_CONTENT" > $CONFIG
 fi

--- a/redis/init-redis
+++ b/redis/init-redis
@@ -53,18 +53,18 @@ echo "loglevel ${REDIS_LOGLEVEL:-notice}" >> "$REDIS_CONFIG"
 echo "syslog-enabled yes" >> "$REDIS_CONFIG"
 # TLS setup
 if [ -n "$REDIS_CERT" ] && [ -n "$REDIS_KEY" ]; then
-    echo "$REDIS_CERT" > "$API_REDIS_SSL_CERTFILE"
-    echo "$REDIS_KEY" > "$API_REDIS_SSL_KEYFILE"
-    chmod 0600 "$API_REDIS_SSL_CERTFILE" "$API_REDIS_SSL_KEYFILE"
+    echo "$REDIS_CERT" > "$REDIS_SSL_CERTFILE"
+    echo "$REDIS_KEY" > "$REDIS_SSL_KEYFILE"
+    chmod 0600 "$REDIS_SSL_CERTFILE" "$REDIS_SSL_KEYFILE"
 fi
 
 if [ -f "$REDIS_SSL_CERTFILE" ] && [ -f "$REDIS_SSL_KEYFILE" ];then
     cat >> "$REDIS_CONFIG" <<EOF
 port 0
 tls-port ${REDIS_PORT:-6379}
-tls-cert-file $API_REDIS_SSL_CERTFILE
+tls-cert-file $REDIS_SSL_CERTFILE
 tls-key-file $API_REDIS_SSL_KEYFILE
-tls-ca-cert-file $API_REDIS_SSL_CERTFILE
+tls-ca-cert-file $REDIS_SSL_CERTFILE
 tls-protocols TLSv1.3
 EOF
 else

--- a/solr/init-solr
+++ b/solr/init-solr
@@ -10,9 +10,15 @@ export SOLR_LOGS_DIR=$LOG_DIR
 export SOLR_JETTY_HOST="0.0.0.0"
 export SOLR_PID_DIR=/tmp/$SERVICE
 
-trap "rm -rf $temp_dir" EXIT
-trap "solr stop -p $SOLR_PORT" SIGINT SIGTERM ERR
 mkdir $SOLR_PID_DIR
+
+clenup(){
+    rm -fr $SOLR_PID_DIR
+    rm -rf $temp_dir
+    solr stop -p $SOLR_PORT
+}
+trap cleanup EXIT
+
 configure_solr=false
 is_solr_running(){
      curl -s "http://localhost:$1/solr/admin/info/system"| grep -q "solr_home"

--- a/solr/init-solr
+++ b/solr/init-solr
@@ -10,7 +10,7 @@ export SOLR_LOGS_DIR=$LOG_DIR
 export SOLR_JETTY_HOST="0.0.0.0"
 export SOLR_PID_DIR=/tmp/$SERVICE
 
-mkdir $SOLR_PID_DIR
+mkdir -p $SOLR_PID_DIR
 
 clenup(){
     rm -fr $SOLR_PID_DIR

--- a/solr/init-solr
+++ b/solr/init-solr
@@ -42,4 +42,4 @@ if $configure_solr ;then
     solr stop -p $SOLR_PORT
 fi
 rm -rf "$temp_dir"
-solr start -f -force -s ${DATA_DIR}
+exec solr start -f -force -s ${DATA_DIR}


### PR DESCRIPTION
Yet another PR, sorry - I hope this'll be the last one for a while.

What does this do?

I want to centralize the container conda start script creation

Why?

Many packages like redis don't even need python making the conda envs super small. I feel like having to install the freva-rest-api conda package to get a start script is just too much.

 In the dployment I'd be able to do this after I have installed the conda packages need:

```console
micromamba install -y -c conda-forge redis-server
curl -sSL https://raw.githubusercontent.com/FREVA-CLINT/freva-service-config/refs/heads/add-conda-recipe/conda-services/create.sh | bash

start-freva-service -s redis                                                                                                                                        
Created Redis with config:
user default on +@all ~* &* nopass
loglevel notice
syslog-enabled yes
port 6379
dir /opt/conda-forge/envs/web/var/freva-rest-server/redis
logfile /opt/conda-forge/envs/web/var/log/freva-rest-server/redis/redis-6379.log
pidfile /tmp/redis-server-6379.pid

```

I mean the cleanest solution would be to create a conda-recipe for each service, but I think that's too much.