### PR TITLE
Minor changes to make the auth flow work with OIDC on freva-web

### DIFF
--- a/keycloak/import/realm-export.json
+++ b/keycloak/import/realm-export.json
@@ -668,8 +668,9 @@
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
+      "secret": "",
       "redirectUris": [
-        "/*"
+        "*"
       ],
       "webOrigins": [
         "/*"
@@ -681,7 +682,7 @@
       "implicitFlowEnabled": true,
       "directAccessGrantsEnabled": true,
       "serviceAccountsEnabled": false,
-      "publicClient": true,
+      "publicClient": false,
       "frontchannelLogout": true,
       "protocol": "openid-connect",
       "attributes": {


### PR DESCRIPTION
In this small PR I'm going to propose a minor change on the client secret and redirectUris of the Keycloak configuration as a discussion point to as a final result, the auth flow of freva-web works. To implement the auth flow on web, we need to provide the client-secret, so I decided to consider the client as private to be able to enable the `Client authentication` and instead of adding one more password to our passwords pool, I kept `client_secret` empty for now. Also by keeping this secret key empty, we don't define a new client_secret environment variable on `freva-web` side! But in the future to make it more robust, we can dedicate a strong password on production side.

Also to to be able properly redirect from `oidc/callback` to `/` we need to open the `redirectUris` for all or define for cases.
At the end if you don't see any caveat on changing these two on our auth stack, we can reflect it on the production. Otherwise let's figure it here fist in the dev env.