### PR TITLE
hotfix: remove all lower case from solr managed_schema

### DIFF
--- a/solr/managed-schema.xml
+++ b/solr/managed-schema.xml
@@ -24,14 +24,12 @@
   <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100" multiValued="true">
     <analyzer type="index">
       <tokenizer class="solr.KeywordTokenizerFactory"/>
-      <filter class="solr.LowerCaseFilterFactory"/>
       <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
       <filter class="solr.FlattenGraphFilterFactory"/>
     </analyzer>
 
     <analyzer type="query">
       <tokenizer class="solr.KeywordTokenizerFactory"/>
-      <filter class="solr.LowerCaseFilterFactory"/>
       <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
       <filter class="solr.FlattenGraphFilterFactory"/>
     </analyzer>
@@ -40,14 +38,12 @@
   <fieldType name="extra_facet" class="solr.TextField" positionIncrementGap="100" multiValued="true">
     <analyzer type="index">
       <tokenizer class="solr.KeywordTokenizerFactory"/>
-      <filter class="solr.LowerCaseFilterFactory"/>
       <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
       <filter class="solr.FlattenGraphFilterFactory"/>
     </analyzer>
 
     <analyzer type="query">
       <tokenizer class="solr.KeywordTokenizerFactory"/>
-      <filter class="solr.LowerCaseFilterFactory"/>
       <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
       <filter class="solr.FlattenGraphFilterFactory"/>
     </analyzer>


### PR DESCRIPTION
@antarcticrainforest could you please have a look this change to see if this removing lowercase in text_general and query, breaks anything in the infra?

where does this change come from?
we were looking for the root cause of the following issue that when we search for `prAdjust` it automatically lowercase the value of and deliver `pradjust` and we found out Solr on top, lowercase all queries.

```bash
$ curl -s "https://www-regiklim.dkrz.de/api/freva-nextgen/databrowser/metadata-search/freva/file?facets=variable&project=nukleus&product=ceu-3i&institute=clmcom-btu&model=ec-earth-consortium-ec-earth3-veg-clmcom-btu-icon-2-6-5-rc-nukleus-x2yn2-v1-qdm-hyras-de-1961-1990&experiment=ssp370-gwl2k&time_frequency=1day&variable=pr&variable=prc&variable=prl&variable=prAdjust"

{"total_count":30,"facets":{"variable":["pradjust",30]},"facet_mapping":{"variable":"variable"},"primary_facets":["project","product","institute","model","experiment","time_frequency","realm","variable","ensemble","time_aggregation"]}
```

Also we observed, our freva-rest is handling the upper and lower case in search values of facets properly.

Could you see does this change would break anything in the code base.