### PR TITLE
change: Add file system metadata facets in Solr managed-schema

### DIFF
--- a/solr/managed-schema.xml
+++ b/solr/managed-schema.xml
@@ -96,4 +96,11 @@
   <!-- define the future dataset definition. -->
   <field name="future" type="string" stored="true" indexed="false" multiValued="false" default=""/>
   <field name="future_id" type="string" stored="true" indexed="false" multiValued="false" default="-1"/>
+  <!-- File system metadata -->
+  <field name="file_size" type="plong" stored="true" indexed="true"/>
+  <field name="mime_type" type="string" stored="true" indexed="true"/>
+  <field name="last_modified" type="pdate" stored="true" indexed="true"/>
+  <field name="checksum" type="string" stored="true" indexed="false"/>
+  <field name="access" type="string" stored="true" indexed="true" default="public"/>
+  <field name="group" type="extra_facet" stored="true" indexed="true" multiValued="true"/>
 </schema>

--- a/solr/managed-schema.xml
+++ b/solr/managed-schema.xml
@@ -57,8 +57,7 @@
   <field name="_version_" type="plong" indexed="true" stored="true"/>
   <field name="file" type="string" multiValued="false" indexed="true" required="true" stored="true"/>
   <field name="uri" type="string" multiValued="false" indexed="true" required="true" stored="true"/>
-  <field name="timestamp" type="pfloat" indexed="false" stored="true"/>
-  <field name="creation_time" type="pdate" indexed="true" stored="false" default="NOW"/>
+  <field name="crawl_date" type="pdate" indexed="true" stored="false" default="NOW"/>
 
   <!-- we need this to search for latest version.
   If not it won't work for entries not being versioned at all -->
@@ -85,12 +84,10 @@
   <!-- define extra facet name that are not displayd by default. -->
   <field name="dataset" type="extra_facet" stored="true" indexed="true" multiValued="false"/>
   <field name="driving_model" type="extra_facet" stored="true" indexed="true" multiValued="true" />
-  <field name="format" type="extra_facet" stored="true" indexed="true" multiValued="false" default="nc"/>
   <field name="grid_id" type="extra_facet" stored="true" indexed="true" multiValued="true"/>
   <field name="level_type" type="extra_facet" stored="true" indexed="true" multiValued="true" default="2d"/>
   <field name="rcm_name" type="extra_facet" stored="true" indexed="true" multiValued="true" />
   <field name="rcm_version" type="extra_facet" stored="true" indexed="true" multiValued="true" />
-  <field name="user" type="extra_facet" stored="true" indexed="true" multiValued="false" />
   <field name="processing_level" type="extra_facet" stored="true" indexed="true" multiValued="false" default="raw"/>
   <field name="data_type" type="extra_facet" stored="true" indexed="true" multiValued="false" default="model-data"/>
   <!-- define the future dataset definition. -->
@@ -98,9 +95,9 @@
   <field name="future_id" type="string" stored="true" indexed="false" multiValued="false" default="-1"/>
   <!-- File system metadata -->
   <field name="file_size" type="plong" stored="true" indexed="true"/>
-  <field name="mime_type" type="string" stored="true" indexed="true"/>
+  <field name="format" type="extra_facet" stored="true" indexed="true" multiValued="false" default="nc"/>
   <field name="last_modified" type="pdate" stored="true" indexed="true"/>
-  <field name="checksum" type="string" stored="true" indexed="false"/>
   <field name="access" type="string" stored="true" indexed="true" default="public"/>
+  <field name="user" type="extra_facet" stored="true" indexed="true" multiValued="false" />
   <field name="group" type="extra_facet" stored="true" indexed="true" multiValued="true"/>
 </schema>

--- a/solr/managed-schema.xml
+++ b/solr/managed-schema.xml
@@ -57,7 +57,7 @@
   <field name="_version_" type="plong" indexed="true" stored="true"/>
   <field name="file" type="string" multiValued="false" indexed="true" required="true" stored="true"/>
   <field name="uri" type="string" multiValued="false" indexed="true" required="true" stored="true"/>
-  <field name="crawl_date" type="pdate" indexed="true" stored="false" default="NOW"/>
+  <field name="creation_time" type="pdate" indexed="true" stored="false" default="NOW"/>
 
   <!-- we need this to search for latest version.
   If not it won't work for entries not being versioned at all -->


### PR DESCRIPTION
This PR adds file system metadata fields to `managed_schema.xml` to enrich the search results displayed in the new data browser design.
These fields are in principal beneficial for web-based usage and generally cloud-hosted data, where file system metadata is not directly accessible to the user OR for the cases that user is searching the data on their own local machine using `freva-client`, not data pool. In contrast, when using `freva-client` as a CLI on a system where the data lives locally (e.g. Levante), these fields are less critical since users can inspect file system metadata directly.
The `timestamp` field has also been removed as it is currently unused. It represents the same moment of `creation_time` in Unix epoch format.