### PR TITLE
Add versitygw as the freva-versity cloud service

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        service: [mongo, mysql, redis, solr, nginx]
+        service: [mongo, mysql, redis, solr, nginx, versitygw]
 
     steps:
 

--- a/docker-scripts/healthchecks.sh
+++ b/docker-scripts/healthchecks.sh
@@ -93,6 +93,10 @@ case "$SERVICE" in
         nginx -t -c $config
         curl -s https://localhost:${NGINX_PORT:-443}/ --insecure || exit 1
         ;;
+    versitygw)
+        command -v versitygw >/dev/null 2>&1 || { echo "versitygw not found"; exit 1; }
+        versitygw --version >/dev/null 2>&1 || { echo "versitygw not runnable"; exit 1; }
+        ;;
     *)
         echo "❌ Unknown service: $SERVICE" >&2
         exit 1

--- a/local-build.sh
+++ b/local-build.sh
@@ -57,7 +57,7 @@ ENV_VARS=(
 )
 
 ### Determine which services to build
-ALL_SERVICES=(mysql solr mongo redis nginx)
+ALL_SERVICES=(mysql solr mongo redis nginx versitygw)
 if [[ -n "$SERVICE" ]]; then
   SERVICES=("$SERVICE")
 else

--- a/versitygw/init-versitygw
+++ b/versitygw/init-versitygw
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+set -o nounset -o pipefail -o errexit
+[ "${DEBUG:-}" = "true" ] && set -x
+
+export SERVICE=versitygw
+
+TMP_DIR=$(mktemp -d --suffix=_versitygw -q)
+CONFIG="$CONFIG_DIR/data-portal-cluster-config.json"
+JSON="{}"
+
+
+# IMPORTANT: one subdir == one bucket
+BUCKET_DIR="${API_S3_BUCKET_DIR:-$DATA_DIR/buckets}"
+IAM_DIR="${API_S3_IAM_DIR:-$DATA_DIR/.iam}"
+VERSION_DIR="${API_S3_VERSIONING_DIR:-$DATA_DIR/.versions}"
+mkdir -p "$BUCKET_DIR" "$IAM_DIR" "$VERSION_DIR" "$LOG_DIR"
+
+S3_PORT="${API_S3_PORT:-7070}"
+S3_REGION="${API_S3_REGION:-us-east-1}"
+WEBUI_PORT="${API_S3_WEBUI_PORT:-}"
+LOG_FILE="$LOG_DIR/versitygw-${S3_PORT}.log"
+
+
+print_logo() {
+    [ "${API_S3_NO_BANNER:-}" = "1" ] && return 0
+    local B C Y R
+    B=$'\e[94m' # bright blue
+    C=$'\e[96m' # bright cyan
+    Y=$'\e[93m' # bright yellow
+    R=$'\e[0m' # reset
+    cat <<ART1
+                                  ${C}   ▓▓▓▓▓▓${R}
+                               ${B}███${C} ▓▓▓▓▓▓▓▓${Y} ▒▒▒▒${R}
+                             ${B}█████${C} ▓▓▓▓▓▓▓▓${Y} ▒▒▒▒▒▒${R}
+                     ${B}█████████████${C} ▓▓▓▓▓▓▓▓${Y} ▒▒▒▒▒▒▒▒${R}
+                 ${B}█████████████████${C} ▓▓▓▓▓▓▓▓${Y} ▒▒▒▒▒▒▒▒▒${R}
+                ${B}██████████████      ${C}▓▓▓▓▓▓▓${Y} ▒▒▒▒▒▒▒▒▒▒${R}
+              ${B}████████████              ${C}▓▓▓${Y} ▒▒▒▒▒▒▒▒▒▒▒${R}
+              ${B}██████████                  ${C}▓${Y} ▒▒▒▒▒▒▒▒▒▒▒${R}
+             ${B}██████████${R}
+             ${B}█████████            ████      ${C}▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓${R}
+           ${B}██████████            ███ ██      ${C}▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓${R}
+         ${B}███████████              ████       ${C}▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓${R}
+       ${B}█████████████                           ${C}▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓${R}
+      ${B}██████████████${R}
+      ${B}█████████████                      ███       ██████████████${R}
+     ${B}██████████████                   ████████████  █████████████${R}
+     ${B}██████████████                  ████████████████████████████${R}
+     ${B}██████████████                  ████████████████████████████${R}
+     ${B}██████████████                  ███████████████████████████${R}
+      ${B}█████████████                   █████████████████████████${R}
+       ${B}████████████                    ███████████████████████${R}
+        ${B}███████████                     █████████████████████${R}
+         ${B}██████████                      ██████████████████${R}
+            ${B}████████                      ██████████████${R}
+                     ${B}▄▖▄▖▄▖▖▖▄▖${R}  ▖▖▄▖▄▖▄▖▄▖▄▖▖▖
+                     ${B}▙▖▙▘▙▖▌▌▌▌${R}▄▖▌▌▙▖▙▘▚ ▐ ▐ ▌▌
+                     ${B}▌ ▌▌▙▖▚▘▛▌${R}  ▚▘▙▖▌▌▄▌▟▖▐ ▐ 
+                      ${Y}versitygw - S3 gateway${R}
+ART1
+}
+
+parse_json_value() {
+    echo "$JSON" | jq -r ".${1} // \"\""
+}
+
+# Generic passthrough: API_S3_VGW_<NAME> -> VGW_<NAME>.
+# It covers every versitygw option
+passthrough_options() {
+    local name
+    for name in $(compgen -e); do
+        case "$name" in
+            API_S3_VGW_*)
+                export "VGW_${name#API_S3_VGW_}=${!name}"
+                ;;
+        esac
+    done
+}
+
+# build config
+build_config() {
+    if [ "${OVERRIDE:-0}" = "1" ]; then
+        rm -rf "$CONFIG"
+    fi
+    if [ "${CONFIG_CONTENT:-}" ] && [ ! -f "$CONFIG" ]; then
+        mkdir -p "$CONFIG_DIR"
+        echo "$CONFIG_CONTENT" > "$CONFIG"
+    fi
+    if [ -f "$CONFIG" ]; then
+        JSON=$(base64 --decode < "$CONFIG")
+    fi
+
+    # Root credentials
+    export ROOT_ACCESS_KEY="${ROOT_ACCESS_KEY:-$(parse_json_value s3_access_key)}"
+    export ROOT_SECRET_KEY="${ROOT_SECRET_KEY:-$(parse_json_value s3_secret_key)}"
+    if [ -z "$ROOT_ACCESS_KEY" ] || [ -z "$ROOT_SECRET_KEY" ]; then
+        echo "[Error] versitygw: ROOT_ACCESS_KEY / ROOT_SECRET_KEY must be provided" >&2
+        exit 1
+    fi
+
+    # Optional TLS from the config blob
+    local s3_cert s3_key
+    s3_cert=$(parse_json_value ssl_cert)
+    s3_key=$(parse_json_value ssl_key)
+    local certfile="${API_S3_SSL_CERTFILE:-$TMP_DIR/s3-cert.crt}"
+    local keyfile="${API_S3_SSL_KEYFILE:-$TMP_DIR/s3-key.key}"
+    if [ -n "$s3_cert" ] && [ -n "$s3_key" ]; then
+        echo "$s3_cert" > "$certfile"
+        echo "$s3_key"  > "$keyfile"
+        chmod 0600 "$certfile" "$keyfile"
+    fi
+    if [ -f "$certfile" ] && [ -f "$keyfile" ]; then
+        export VGW_CERT="$certfile" VGW_KEY="$keyfile"
+    fi
+}
+
+# Freva-managed values
+set_managed_env() {
+    export VGW_PORT=":${S3_PORT}"
+    export VGW_REGION="$S3_REGION"
+    export VGW_IAM_DIR="$IAM_DIR"
+    export VGW_VERSIONING_DIR="$VERSION_DIR"
+    export VGW_HEALTH="${API_S3_HEALTH:-/health}"
+    export VGW_ACCESS_LOG="$LOG_FILE"
+    if [ -n "$WEBUI_PORT" ]; then
+        export VGW_WEBUI_PORT=":${WEBUI_PORT}"
+    fi
+    if [ "${API_S3_WEBUI_NO_TLS:-}" = "true" ]; then
+        export VGW_WEBUI_NO_TLS="true"
+    fi
+    if [ "${API_S3_READONLY:-}" = "true" ]; then
+        export VGW_READ_ONLY="true"
+    fi
+    return 0
+}
+
+
+print_logo
+passthrough_options
+build_config
+set_managed_env
+
+exec versitygw posix "$BUCKET_DIR"

--- a/versitygw/requirements.txt
+++ b/versitygw/requirements.txt
@@ -1,0 +1,4 @@
+versitygw=1.4.1
+curl
+jq
+procps-ng


### PR DESCRIPTION
We already added a new recipe for `versitygw` and it's installable conda-based and now, via this PR, `versitygw` is added to our Freva images as `freva-versity` for better management. 
But that's only the `what` part of the journey. Now that we're educated about this software, we should think about `how` to deploy it and if we can afford to adopt it as a freva service.