### PR TITLE
change: adding STAC-Collection entries into the Solr/managed-schema

### DIFF
--- a/solr/managed-schema.xml
+++ b/solr/managed-schema.xml
@@ -96,4 +96,21 @@
   <!-- define the future dataset definition. -->
   <field name="future" type="string" stored="true" indexed="false" multiValued="false" default=""/>
   <field name="future_id" type="string" stored="true" indexed="false" multiValued="false" default="-1"/>
+  <!-- STAC collection-level metadata fields
+       Every field is a multi-valued, axis-tagged string. Each entry is
+       "<axis>|<value>", e.g. "project|CMIP6 Global Climate" or
+       "product|Model Output". These field are optional and if they are
+       avaiable, the STAC RestAPI layer takes care of the parsing, for
+       the active collection axis -->
+  <field name="collection_title" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="collection_description" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="collection_license" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="collection_license_url" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="collection_keywords" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="collection_thumbnail_url" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="collection_thumbnail_type" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="collection_documentation_url" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="collection_bbox" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="collection_time_start" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="collection_time_end" type="string" indexed="false" stored="true" multiValued="true"/>
 </schema>

--- a/solr/managed-schema.xml
+++ b/solr/managed-schema.xml
@@ -102,15 +102,15 @@
        "product|Model Output". These field are optional and if they are
        avaiable, the STAC RestAPI layer takes care of the parsing, for
        the active collection axis -->
-  <field name="collection_title" type="string" indexed="false" stored="true" multiValued="true"/>
-  <field name="collection_description" type="string" indexed="false" stored="true" multiValued="true"/>
-  <field name="collection_license" type="string" indexed="false" stored="true" multiValued="true"/>
-  <field name="collection_license_url" type="string" indexed="false" stored="true" multiValued="true"/>
-  <field name="collection_keywords" type="string" indexed="false" stored="true" multiValued="true"/>
-  <field name="collection_thumbnail_url" type="string" indexed="false" stored="true" multiValued="true"/>
-  <field name="collection_thumbnail_type" type="string" indexed="false" stored="true" multiValued="true"/>
-  <field name="collection_documentation_url" type="string" indexed="false" stored="true" multiValued="true"/>
-  <field name="collection_bbox" type="string" indexed="false" stored="true" multiValued="true"/>
-  <field name="collection_time_start" type="string" indexed="false" stored="true" multiValued="true"/>
-  <field name="collection_time_end" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="stac_collection_title" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="stac_collection_description" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="stac_collection_license" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="stac_collection_license_url" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="stac_collection_keywords" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="stac_collection_thumbnail_url" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="stac_collection_thumbnail_type" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="stac_collection_documentation_url" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="stac_collection_bbox" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="stac_collection_time_start" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="stac_collection_time_end" type="string" indexed="false" stored="true" multiValued="true"/>
 </schema>


### PR DESCRIPTION
A first step toward enriching waterpark metadata
As discussed in a separate PR, keeping the STAC API enriched with curated, proper metadata requires a few additional facets that aren't currently available but would be nice and valuable to surface there. This PR adds them as optional, non-indexed facets.
The pipeline that I'm dreaming now, is that, after merging this PR, 1. we redeploy the Solr on gems and freva-dev, 2. we provide a `drs_config.toml` specifically on grid-doctor for waterpark to each data-provider, curates their own metadata there through PR procedure. 3. Then our nightly crawler pick the official config file from deploy_instance repo and the waterpark config bit from grid-doctor and merge both together and then crawl.