### PR TITLE
Hotfix: remove invalid adminUrl from freva client

### DIFF
--- a/keycloak/import/realm-export.json
+++ b/keycloak/import/realm-export.json
@@ -653,7 +653,7 @@
     "name" : "${client_freva}",
     "description" : "",
     "rootUrl" : "${authBaseUrl}",
-    "adminUrl" : "${authBaseUrl}",
+    "adminUrl" : "",
     "baseUrl" : "",
     "surrogateAuthRequired" : false,
     "enabled" : true,


### PR DESCRIPTION
The `freva` client in keycloak file had `adminUrl` set to the placeholder `${authBaseUrl}` which is not compatible with the latest Keycloak version. It seems the placeholder is only resolved by Keycloak for its built-in clients like account, security-admin-console, and so on; for a custom client it stays an unresolved string, which is not a valid URL anymore and as a result it stops Keycloak on dev env to stay up. Removing adminURL seems to make the dev env work
